### PR TITLE
Update sample Vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,11 +4,19 @@ import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
+  // When running in dev mode, serve files with CORS enabled to allow cross-origin requests from test environments.
+  const cors = mode === "development";
+
+  // To simplify the workflow when working locally, make the output file names static.
+  const entryFilenames = mode === "development" ? {
+    entryFileNames: "assets/localdev_app.js",
+    chunkFileNames: "assets/localdev_app.js",
+    assetFileNames: "assets/localdev_app.[ext]",
+  } : {};
+
   return {
     plugins: [react()],
-    server: {
-      cors: mode === "development",
-    },
+    server: { cors },
     build: {
       rollupOptions: {
         output: {
@@ -16,6 +24,7 @@ export default defineConfig(({ mode }) => {
           manualChunks: undefined,
           // Avoid chunk splitting for dynamic imports.
           inlineDynamicImports: true,
+          ...entryFilenames,
         },
       },
       // Massively increase the inline limit to prevent bundle splitting.

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,11 +4,24 @@ import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-
   return {
     plugins: [react()],
     server: {
       cors: mode === "development",
     },
+    build: {
+      rollupOptions: {
+        output: {
+          // Avoid chunk splitting for the main entry point.
+          manualChunks: undefined,
+          // Avoid chunk splitting for dynamic imports.
+          inlineDynamicImports: true,
+        },
+      },
+      // Massively increase the inline limit to prevent bundle splitting.
+      assetsInlineLimit: 100000000,
+      // Prevent CSS splitting.
+      cssCodeSplit: false,
+    }
   };
 });


### PR DESCRIPTION
Update the sample Vite config to:
- produce a single JS bundle: this resolves the current limitation around Kraken Apps needing to be a single JS bundle file (hopefully going away soon!)
- produce a bundle with a stable name working locally to simplify the workflow of trying and updating an app